### PR TITLE
Experimental: Move path to constructor; improve path processing

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,22 +12,22 @@ final router = GoRouter(
     GoRoute(
       // use the route class' [path] property to define this segment of the
       // route path.
-      path: const RootRoute().path,
+      path: RootRoute.root.path,
       builder: (context, state) => const RootPage(),
       routes: [
         GoRoute(
-          path: const DashboardRoute().path,
+          path: RootRoute.dashboard.path,
           builder: (context, state) => const DashboardPage(),
         ),
       ],
     ),
     GoRoute(
-      path: const ProfileRoute().path,
+      path: ProfileRoute.root.path,
       redirect: (context, state) {
         // use your factory class to validate the route data.
         if (!const ProfileRouteDataFactory().containsData(state)) {
           // when redirecting, use the `fullPath` property.
-          return const RootRoute().fullPath;
+          return RootRoute.root.fullPath;
         }
 
         return null;
@@ -43,7 +43,7 @@ final router = GoRouter(
       },
       routes: [
         GoRoute(
-          path: const ProfileEditRoute().path,
+          path: ProfileRoute.edit.path,
           builder: (context, state) => ProfileEditPage(
             queryParams: getQueryParams(state),
           ),
@@ -82,17 +82,17 @@ class NavButtons extends StatelessWidget {
       children: [
         const SizedBox(height: 12),
         ElevatedButton(
-          onPressed: () => const RootRoute().go(context),
+          onPressed: () => RootRoute.root.go(context),
           child: const Text('Go to root'),
         ),
         const SizedBox(height: 12),
         ElevatedButton(
-          onPressed: () => const DashboardRoute().go(context),
+          onPressed: () => RootRoute.dashboard.go(context),
           child: const Text('Go to dashboard'),
         ),
         const SizedBox(height: 12),
         ElevatedButton(
-          onPressed: () => const ProfileRoute().go(
+          onPressed: () => ProfileRoute.root.go(
             context,
             data: const ProfileRouteData(userId: '123'),
           ),
@@ -100,7 +100,7 @@ class NavButtons extends StatelessWidget {
         ),
         const SizedBox(height: 12),
         ElevatedButton(
-          onPressed: () => const ProfileEditRoute().go(
+          onPressed: () => ProfileRoute.edit.go(
             context,
             data: const ProfileRouteData(userId: '123'),
             query: {'foo': 'bar'},

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -78,7 +78,7 @@ class ProfileRouteDataFactory extends SimpleRouteDataFactory<ProfileRouteData> {
 }
 
 // Define your route as a child of [DataRoute].
-final class ProfileRoute extends DataRoute<ProfileRouteData> {
+class ProfileRoute extends DataRoute<ProfileRouteData> {
   // Since this is a [DataRoute], the path should contain some dynamic variable,
   // such as a userId. e.g. '/profile/:userId'.
   //
@@ -98,7 +98,7 @@ final class ProfileRoute extends DataRoute<ProfileRouteData> {
 
 // Define your route as a child of [DataRoute] with its appropriate data type
 // and implement the [ChildRoute] interface.
-final class ProfileEditRoute extends DataRoute<ProfileRouteData>
+class ProfileEditRoute extends DataRoute<ProfileRouteData>
     implements ChildRoute<ProfileRoute> {
   ProfileEditRoute() : super('edit');
 

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -6,18 +6,21 @@ import 'package:simple_routes/simple_routes.dart';
 // Declare your route as a child of [SimpleRoute] or
 // [DataRoute] (see more below).
 class RootRoute extends SimpleRoute {
-  const RootRoute();
+  // Use the [root] constructor to signify that this is the root route ('/').
+  RootRoute() : super.root();
 
-  // override the [path] to define the path of this route.
-  @override
-  final String path = '/';
+  // Create static instances of this route and its children to aid in
+  // navigation and to reduce the number of instantiations.
+  static final RootRoute root = RootRoute();
+  static final DashboardRoute dashboard = DashboardRoute();
 }
 
 // Simple child route
 // Declare your child route as a child of [SimpleRoute] and an implementation
 // of the [ChildRoute] interface.
 class DashboardRoute extends SimpleRoute implements ChildRoute<RootRoute> {
-  const DashboardRoute();
+  // Set the [path] in the super to define the path of this route.
+  DashboardRoute() : super('dashboard');
 
   // override the [path] to define the path of this route.
   // Note: This should be everything that comes _after_ the parent's path,
@@ -27,7 +30,7 @@ class DashboardRoute extends SimpleRoute implements ChildRoute<RootRoute> {
 
   // override the [parent] getter to return an instance of the parent route.
   @override
-  RootRoute get parent => const RootRoute();
+  RootRoute get parent => RootRoute.root;
 }
 
 // Simple data route
@@ -75,36 +78,31 @@ class ProfileRouteDataFactory extends SimpleRouteDataFactory<ProfileRouteData> {
 }
 
 // Define your route as a child of [DataRoute].
-class ProfileRoute extends DataRoute<ProfileRouteData> {
-  const ProfileRoute();
-
-  // override the [path] getter to define the path of this route.
-  // since this is a [DataRoute], it should contain some dynamic variable, such
-  // as a userId. e.g. '/profile/:userId'.
+final class ProfileRoute extends DataRoute<ProfileRouteData> {
+  // Since this is a [DataRoute], the path should contain some dynamic variable,
+  // such as a userId. e.g. '/profile/:userId'.
   //
-  // use the [withPrefix] helper method to add the colon prefix to your
-  // parameter in the template, and use the [join] method to join the path
-  // segments together.
+  // Use the [withPrefix] helper method to inject your parameter into the
+  // template, and use the [join] constructor to join the path segments
+  // together with the appropriate slashes.
   //
-  // you can craft this template yourself, but the helper methods are here to
+  // You could craft this template yourself, but the helper methods are here to
   // minimize the chance of error.
-  @override
-  String get path => join(['/profile', withPrefix(RouteParams.userId)]);
+  ProfileRoute() : super.join(['profile', withPrefix(RouteParams.userId)]);
+
+  static final ProfileRoute root = ProfileRoute();
+  static final ProfileEditRoute edit = ProfileEditRoute();
 }
 
 // Child data route
 
 // Define your route as a child of [DataRoute] with its appropriate data type
 // and implement the [ChildRoute] interface.
-class ProfileEditRoute extends DataRoute<ProfileRouteData>
+final class ProfileEditRoute extends DataRoute<ProfileRouteData>
     implements ChildRoute<ProfileRoute> {
-  const ProfileEditRoute();
-
-  // override the [path] getter with this route's path.
-  @override
-  String get path => 'edit';
+  ProfileEditRoute() : super('edit');
 
   // override the [parent] getter to return an instance of this route's parent.
   @override
-  ProfileRoute get parent => const ProfileRoute();
+  ProfileRoute get parent => ProfileRoute.root;
 }

--- a/lib/src/base_route.dart
+++ b/lib/src/base_route.dart
@@ -21,14 +21,37 @@ class SegmentedPath extends PathData {
 
 /// An abstract class to serve as the parent for all routes.
 abstract class BaseRoute {
-  const BaseRoute();
+  const BaseRoute(this._pathData);
 
-  /// The sub-path for this route. e.g. 'login'.
-  abstract final String path;
+  final PathData _pathData;
+
+  /// The path for this route. e.g. '/login'.
+  String get path => _getPath();
 
   String get fullPath {
     if (this is ChildRoute) {
       return join([(this as ChildRoute).parent.fullPath, path]);
+    }
+
+    return path;
+  }
+
+  String _getPath() {
+    // get the path String from the path data.
+    final path = switch (_pathData) {
+      AtomicPath(:final path) => path,
+      SegmentedPath(:final segments) => join(segments),
+    };
+
+    // if this route is a child but the path contains a slash, remove it.
+    if (this is ChildRoute && path.startsWith('/')) {
+      return path.substring(1);
+    }
+
+    // if this route is NOT a child and the path does NOT contain a slash,
+    // add one.
+    if (this is! ChildRoute && !path.startsWith('/')) {
+      return '/$path';
     }
 
     return path;

--- a/lib/src/base_route.dart
+++ b/lib/src/base_route.dart
@@ -1,6 +1,24 @@
 import 'package:simple_routes/src/child_route.dart';
 import 'package:simple_routes/src/utils.dart';
 
+sealed class PathData {
+  const PathData();
+}
+
+class AtomicPath extends PathData {
+  const AtomicPath.root() : path = '/';
+  AtomicPath.from(String? path) : path = path?.replaceAll('/', '') ?? '';
+
+  final String path;
+}
+
+class SegmentedPath extends PathData {
+  SegmentedPath(List<String> segments)
+      : segments = segments.map((s) => s.replaceAll('/', '')).toList();
+
+  final List<String> segments;
+}
+
 /// An abstract class to serve as the parent for all routes.
 abstract class BaseRoute {
   const BaseRoute();

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -5,7 +5,14 @@ import 'package:simple_routes/src/base_route.dart';
 
 /// A route that contains no parameters.
 abstract class SimpleRoute extends BaseRoute {
-  const SimpleRoute();
+  /// Create a simple route with the supplied [path].
+  SimpleRoute(String? path) : super(AtomicPath.from(path));
+
+  /// Create a root route ('/').
+  SimpleRoute.root() : super(const AtomicPath.root());
+
+  /// Create a route path from the provided [segments].
+  SimpleRoute.join(List<String> segments) : super(SegmentedPath(segments));
 
   /// Navigate to this route.
   void go(BuildContext context, {Map<String, String>? query}) {
@@ -16,7 +23,11 @@ abstract class SimpleRoute extends BaseRoute {
 /// A route that contains a parameter. When navigating, data must be supplied
 /// to populate the route.
 abstract class DataRoute<Data extends SimpleRouteData> extends BaseRoute {
-  const DataRoute();
+  /// Create a DataRoute with the provided [path].
+  DataRoute(String? path) : super(AtomicPath.from(path));
+
+  /// Create a data route path from the provided [segments].
+  DataRoute.join(List<String> segments) : super(SegmentedPath(segments));
 
   /// Navigate to this route using the supplied [data].
   void go(

--- a/test/data_route_test.dart
+++ b/test/data_route_test.dart
@@ -36,12 +36,9 @@ class ChildRouteData extends RootRouteData {
 }
 
 class _RootDataRoute extends DataRoute<RootRouteData> {
-  _RootDataRoute(this.onGo);
+  _RootDataRoute(this.onGo) : super(withPrefix(DataRouteParams.userId));
 
   final void Function(String) onGo;
-
-  @override
-  String get path => join(['/', withPrefix(DataRouteParams.userId)]);
 
   // overriding for test purposes only
   @override
@@ -56,15 +53,13 @@ class _RootDataRoute extends DataRoute<RootRouteData> {
 
 class _ChildDataRoute extends DataRoute<ChildRouteData>
     implements ChildRoute<_RootDataRoute> {
-  _ChildDataRoute(this.onGo);
+  _ChildDataRoute(this.onGo)
+      : super.join(['child', withPrefix(DataRouteParams.someValue)]);
 
   final void Function(String) onGo;
 
   @override
   _RootDataRoute get parent => _RootDataRoute((_) {});
-
-  @override
-  String get path => join(['child', withPrefix(DataRouteParams.someValue)]);
 
   // overriding for test purposes only
   @override

--- a/test/simple_route_test.dart
+++ b/test/simple_route_test.dart
@@ -2,26 +2,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_routes/simple_routes.dart';
 
 class _TestSimpleRoute extends SimpleRoute {
-  @override
-  String get path => '/test';
+  _TestSimpleRoute() : super('test');
 }
 
 class _TestSimpleChildRoute extends SimpleRoute
     implements ChildRoute<_TestSimpleRoute> {
-  @override
-  _TestSimpleRoute get parent => _TestSimpleRoute();
+  _TestSimpleChildRoute() : super('child');
 
   @override
-  String get path => 'child';
+  _TestSimpleRoute get parent => _TestSimpleRoute();
 }
 
 class _SecondLevelChildRoute extends SimpleRoute
     implements ChildRoute<_TestSimpleChildRoute> {
-  @override
-  _TestSimpleChildRoute get parent => _TestSimpleChildRoute();
+  _SecondLevelChildRoute() : super('second-level');
 
   @override
-  String get path => 'second-level';
+  _TestSimpleChildRoute get parent => _TestSimpleChildRoute();
 }
 
 void main() {


### PR DESCRIPTION
This is an experimental branch that moves the `path` declaration from an overridden property to a `super` constructor argument.

What this does is gives us the ability to process the supplied `path` value and ensure it is formatted correctly when it is accessed, both via the `path` property and the (unchanged) `fullPath` property.

The downside of this is that we lose the `const` constructors and adding more processing opens up more opportunity for bugs.