### PR TITLE
Update go_router package

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2aa884667eeda3a1c461f31e72af1f77984ab0f29450d8fb12ec1f7bc53eea14"
+      sha256: "4b58412b92bd7d588f904425ef6d41a017da1f097e5e9428d2c27d275777e16e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "11.1.1"
   http_multi_server:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  go_router: ^10.1.0
+  go_router: ^11.1.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  go_router: ^10.1.0
+  go_router: ^11.1.1
   mocktail: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
GoRouter has been updated to 11.1.1 and this project is set to ^10.1.0. This PR updates the main project and example to use 11.1.1.

Note: The GoRouter changelog does mention a breaking change, however, that doesn't seem to affect this project.