### PR TITLE
Upgrade to GoRouter 12.0.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "4b58412b92bd7d588f904425ef6d41a017da1f097e5e9428d2c27d275777e16e"
+      sha256: a206cc4621a644531a2e05e7774616ab4d9d85eab1f3b0e255f3102937fccab1
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.1"
+    version: "12.0.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -326,7 +326,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.8"
+    version: "0.0.10"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  go_router: ^11.1.1
+  go_router: ^12.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  go_router: ^11.1.1
+  go_router: ^12.0.0
   mocktail: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This upgrades Simple Routes to use GoRouter 12.0.0

[changelog]
changed: Changed the version requirement for GoRouter from 11 to 12