### PR TITLE
ref: Change location helpers to use GoRouterState

### DIFF
--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -53,8 +53,8 @@ abstract class BaseRoute {
   /// Determine if this route is an exact match for the current location.
   ///
   /// This is useful for determining if a route is active.
-  bool isCurrentRoute(BuildContext context) {
-    return GoRouterState.of(context).fullPath == _fullPathTemplate;
+  bool isCurrentRoute(GoRouterState state) {
+    return state.fullPath == _fullPathTemplate;
   }
 
   /// Determine if this route is a parent of the current route.
@@ -64,15 +64,19 @@ abstract class BaseRoute {
   /// true.
   ///
   /// This is useful for determining if a parent route is active.
-  bool isParentRoute(BuildContext context) {
-    final location = GoRouterState.of(context).fullPath;
-    return location != _fullPathTemplate &&
-        (location?.startsWith(_fullPathTemplate) ?? false);
+  bool isParentRoute(GoRouterState state) {
+    final location = state.fullPath;
+
+    if (location == null || location == _fullPathTemplate) {
+      return false;
+    }
+
+    return location.startsWith(_fullPathTemplate);
   }
 
   /// Determine if this route is active in any way.
-  bool isActive(BuildContext context) {
-    return isCurrentRoute(context) || isParentRoute(context);
+  bool isActive(GoRouterState state) {
+    return isCurrentRoute(state) || isParentRoute(state);
   }
 
   String get _fullPathTemplate {

--- a/test/simple_route_test.dart
+++ b/test/simple_route_test.dart
@@ -155,7 +155,7 @@ void main() {
               GoRoute(
                 path: const _TestRoute().goPath,
                 builder: (context, state) {
-                  isCurrentRoute = const _TestRoute().isCurrentRoute(context);
+                  isCurrentRoute = const _TestRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -194,7 +194,7 @@ void main() {
               GoRoute(
                 path: '/other-page',
                 builder: (context, state) {
-                  isCurrentRoute = const _TestRoute().isCurrentRoute(context);
+                  isCurrentRoute = const _TestRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -237,7 +237,7 @@ void main() {
                     GoRoute(
                       path: const _TestChildRoute().goPath,
                       builder: (context, state) {
-                        isParent = const _TestRoute().isParentRoute(context);
+                        isParent = const _TestRoute().isParentRoute(state);
                         return const Scaffold(
                           body: Text('Test Route'),
                         );
@@ -281,7 +281,7 @@ void main() {
                 GoRoute(
                   path: '/other-path',
                   builder: (context, state) {
-                    isParent = const _TestRoute().isParentRoute(context);
+                    isParent = const _TestRoute().isParentRoute(state);
                     return const Scaffold(
                       body: Text('Test Route'),
                     );
@@ -323,7 +323,7 @@ void main() {
               GoRoute(
                 path: const _TestRoute().goPath,
                 builder: (context, state) {
-                  isActive = const _TestRoute().isActive(context);
+                  isActive = const _TestRoute().isActive(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -362,7 +362,7 @@ void main() {
               GoRoute(
                 path: '/other-page',
                 builder: (context, state) {
-                  isActive = const _TestRoute().isCurrentRoute(context);
+                  isActive = const _TestRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -401,7 +401,7 @@ void main() {
                   GoRoute(
                     path: const _TestChildRoute().goPath,
                     builder: (context, state) {
-                      isActive = const _TestRoute().isActive(context);
+                      isActive = const _TestRoute().isActive(state);
                       return const Scaffold(
                         body: Text('Test Route'),
                       );


### PR DESCRIPTION
This PR changes the location helpers (`isCurrentRoute`, `isParentRoute`, `isActive`) to use a `GoRouterState` object instead of a `BuildContext`.

This solves an issue where the helpers could not be used inside the `GoRouter`, such as the `redirect` and `build` methods, where they are often most useful.