### PR TITLE
Move "path" into super

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,7 @@ final router = GoRouter(
         // Use a factory to extract your route data.
         // This is especially useful if you have multiple routes that use the
         // same data class or if your route has many parameters.
-        final profileRouteData = ProfileEditRouteData.fromState(state);
+        final profileRouteData = ProfileRouteData.fromState(state);
 
         return ProfilePage(userId: profileRouteData.userId);
       },
@@ -43,6 +43,12 @@ final router = GoRouter(
         GoRoute(
           path: const ProfileEditRoute().path,
           builder: (context, state) => const ProfileEditPage(),
+        ),
+        GoRoute(
+          path: const AdditionalDataRoute().path,
+          builder: (context, state) => AdditionalRouteDataPage(
+            queryValue: AdditionalRouteData.fromState(state).queryValue,
+          ),
         ),
       ],
     ),
@@ -98,11 +104,22 @@ class NavButtons extends StatelessWidget {
         ElevatedButton(
           onPressed: () => const ProfileEditRoute().go(
             context,
-            data: const ProfileEditRouteData(
+            data: const ProfileRouteData(
               userId: '123',
             ),
           ),
           child: const Text('Go to profile edit'),
+        ),
+        const SizedBox(height: 12),
+        ElevatedButton(
+          onPressed: () => const AdditionalDataRoute().go(
+            context,
+            data: const AdditionalRouteData(
+              userId: '123',
+              queryValue: 'hello world!',
+            ),
+          ),
+          child: const Text('Go to Additional Data route'),
         ),
       ],
     );
@@ -163,7 +180,7 @@ class ProfileEditPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final profileRouteData = ProfileEditRouteData.fromState(
+    final profileRouteData = ProfileRouteData.fromState(
       GoRouterState.of(context),
     );
 
@@ -171,6 +188,27 @@ class ProfileEditPage extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text('Profile edit page for ${profileRouteData.userId}'),
+        const NavButtons(),
+      ],
+    );
+  }
+}
+
+class AdditionalRouteDataPage extends StatelessWidget {
+  const AdditionalRouteDataPage({
+    super.key,
+    this.queryValue,
+  });
+
+  final String? queryValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text('Additional Data Route'),
+        Text('Query value: $queryValue'),
         const NavButtons(),
       ],
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,7 +24,7 @@ final router = GoRouter(
       path: const ProfileRoute().path,
       redirect: (context, state) {
         // Use the GoRouterState extension methods to validate the route data.
-        if (state.pathParameters[RouteParams.userId.name] == null) {
+        if (state.pathParameters['userId'] == null) {
           // When redirecting, use the `fullPath` method.
           return const RootRoute().fullPath();
         }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,18 +10,18 @@ final router = GoRouter(
   debugLogDiagnostics: true,
   routes: [
     GoRoute(
-      // Use the [goPath] property to define the route's path.
-      path: const RootRoute().goPath,
+      // Use the [path] property to define the route's path.
+      path: const RootRoute().path,
       builder: (context, state) => const RootPage(),
       routes: [
         GoRoute(
-          path: const DashboardRoute().goPath,
+          path: const DashboardRoute().path,
           builder: (context, state) => const DashboardPage(),
         ),
       ],
     ),
     GoRoute(
-      path: const ProfileRoute().goPath,
+      path: const ProfileRoute().path,
       redirect: (context, state) {
         // Use the GoRouterState extension methods to validate the route data.
         if (state.pathParameters[RouteParams.userId.name] == null) {
@@ -41,10 +41,7 @@ final router = GoRouter(
       },
       routes: [
         GoRoute(
-          path: const ProfileEditRoute().goPath,
-          builder: (context, state) => ProfileEditPage(
-            filter: ProfileEditRouteData.fromState(state).filter,
-          ),
+          path: const ProfileEditRoute().path,
         ),
       ],
     ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,7 @@ final router = GoRouter(
         return null;
       },
       builder: (context, state) {
-        // Use a factory class to extract your route data.
+        // Use a factory to extract your route data.
         // This is especially useful if you have multiple routes that use the
         // same data class or if your route has many parameters.
         final profileRouteData = ProfileEditRouteData.fromState(state);
@@ -42,6 +42,7 @@ final router = GoRouter(
       routes: [
         GoRoute(
           path: const ProfileEditRoute().path,
+          builder: (context, state) => const ProfileEditPage(),
         ),
       ],
     ),
@@ -99,7 +100,6 @@ class NavButtons extends StatelessWidget {
             context,
             data: const ProfileEditRouteData(
               userId: '123',
-              filter: 'filterValue',
             ),
           ),
           child: const Text('Go to profile edit'),
@@ -159,10 +159,7 @@ class ProfilePage extends StatelessWidget {
 class ProfileEditPage extends StatelessWidget {
   const ProfileEditPage({
     super.key,
-    required this.filter,
   });
-
-  final String? filter;
 
   @override
   Widget build(BuildContext context) {
@@ -174,7 +171,6 @@ class ProfileEditPage extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text('Profile edit page for ${profileRouteData.userId}'),
-        Text('Filter: ${filter ?? 'none'}'),
         const NavButtons(),
       ],
     );

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -5,7 +5,7 @@ import 'package:simple_routes/simple_routes.dart';
 
 // Declare your route as a child of [SimpleRoute].
 class RootRoute extends SimpleRoute {
-  const RootRoute() : super('/');
+  const RootRoute() : super(SimpleRoute.root);
 }
 
 // Simple child route

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -3,27 +3,15 @@ import 'package:simple_routes/simple_routes.dart';
 
 // Simple base route
 
-// Declare your route as a child of [SimpleRoute] or
-// [DataRoute] (see more below).
+// Declare your route as a child of [SimpleRoute].
 class RootRoute extends SimpleRoute {
-  const RootRoute();
-
-  // override the [path] to define the path of this route.
-  @override
-  final String path = '/';
+  const RootRoute() : super('/');
 }
 
 // Simple child route
-// Declare your child route as a child of [SimpleRoute] and an implementation
-// of the [ChildRoute] interface.
+// Declare your child route and implement the [ChildRoute] interface.
 class DashboardRoute extends SimpleRoute implements ChildRoute<RootRoute> {
-  const DashboardRoute();
-
-  // override the [path] to define the path of this route.
-  // Note: This should be everything that comes _after_ the parent's path,
-  // without any leading slash. e.g. 'dashboard'.
-  @override
-  final String path = 'dashboard';
+  const DashboardRoute() : super('dashboard');
 
   // override the [parent] getter to return an instance of the parent route.
   @override
@@ -52,38 +40,21 @@ class ProfileRouteData extends SimpleRouteData {
       };
 }
 
-// Define your route as a child of [DataRoute].
+// Define your route as a child of [SimpleDataRoute].
 class ProfileRoute extends SimpleDataRoute<ProfileRouteData> {
-  const ProfileRoute();
-
-  // Override the [path] getter to define the path of this route.
-  // Since this is a [DataRoute], it should contain some dynamic variable, such
-  // as a userId. e.g. '/profile/:userId'.
-  //
-  // Use the `prefixed` property to add the colon (:) prefix to your
-  // parameter in the template, and use the [join] method to join the path
-  // segments together.
-  //
-  // You can craft this template yourself, but the extension methods are
-  // here to help.
-  @override
-  String get path => fromSegments([
-        'profile',
-        RouteParams.userId.template,
-      ]);
+  // Since this is a [SimpleDataRoute], the path should contain some dynamic
+  // variable, such as a userId. Make sure to prefix the value with a colon (:),
+  // just as you would in your GoRoute definition.
+  const ProfileRoute() : super('profile/:userId');
 }
 
 // Child data route
 
-// Define your route as a child of [DataRoute] with its appropriate data type
-// and implement the [ChildRoute] interface.
+// Define your route as a child of [SimpleDataRoute] with its appropriate data
+// type and implement the [ChildRoute] interface.
 class ProfileEditRoute extends SimpleDataRoute<ProfileRouteData>
     implements ChildRoute<ProfileRoute> {
-  const ProfileEditRoute();
-
-  // override the [path] getter with this route's path.
-  @override
-  String get path => 'edit';
+  const ProfileEditRoute() : super('edit');
 
   // override the [parent] getter to return an instance of this route's parent.
   @override

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -20,24 +20,24 @@ class DashboardRoute extends SimpleRoute implements ChildRoute<RootRoute> {
 
 // Simple data route
 
-// Define an enum to use as the path parameter templates for your routes.
-enum RouteParams {
-  userId,
-  filter,
-}
-
 // Define some data for your route as a child of [SimpleRouteData].
 class ProfileRouteData extends SimpleRouteData {
   const ProfileRouteData({required this.userId});
 
+  // Use a factory or named constructor to extract the necessary data from an
+  // instance of [GoRouterState]. This encapsulates any validation or parsing
+  // logic inside the data class instead of doing it inside the route builder.
+  ProfileRouteData.fromState(GoRouterState state)
+      : userId = state.pathParameters['userId']!;
+
   final String userId;
 
-  // Override the [parameters] getter to define the path parameters for this
-  // route, using the enum you defined above.
+  // Override the [parameters] getter to define the parameters for this route.
+  //
+  // In this case, we want to inject the [userId] value into the path, replacing
+  // `:userId` in the path template.
   @override
-  Map<String, String> get parameters => {
-        RouteParams.userId.name: userId,
-      };
+  Map<String, String> get parameters => {'userId': userId};
 }
 
 // Define your route as a child of [SimpleDataRoute].

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -64,24 +64,13 @@ class ProfileEditRoute extends SimpleDataRoute<ProfileRouteData>
 class ProfileEditRouteData extends ProfileRouteData {
   const ProfileEditRouteData({
     required super.userId,
-    required this.filter,
   });
 
-  // Define a factory constructor to easily extract the route data from
-  // [GoRouterState].
+  // Define a factory or named constructor to easily extract the route data
+  // from a [GoRouterState].
   factory ProfileEditRouteData.fromState(GoRouterState state) {
     return ProfileEditRouteData(
-      userId: state.pathParameters[RouteParams.userId.name]!,
-      filter: state.uri.queryParameters[RouteParams.filter.name],
+      userId: state.pathParameters['userId']!,
     );
   }
-
-  final String? filter;
-
-  // Provide an implementation of the [query] getter to define the
-  // query parameters for this route.
-  @override
-  Map<String, String?> get query => {
-        RouteParams.filter.name: filter,
-      };
 }

--- a/example/lib/routes.dart
+++ b/example/lib/routes.dart
@@ -1,26 +1,47 @@
+// ignore_for_file: slash_for_doc_comments
+
 import 'package:go_router/go_router.dart';
 import 'package:simple_routes/simple_routes.dart';
 
-// Simple base route
+/*** Basic Route Example ***/
 
-// Declare your route as a child of [SimpleRoute].
+// Declare a route class as a child of [SimpleRoute] and pass its "path" to
+// the `super` constructor.
+//
+// In this example, we're using the constant `SimpleRoute.root` value, which is
+// a forward slash ('/').
 class RootRoute extends SimpleRoute {
   const RootRoute() : super(SimpleRoute.root);
 }
 
-// Simple child route
-// Declare your child route and implement the [ChildRoute] interface.
+/*** Basic Child Route Example ***/
+
+// Declare a route class, extending [SimpleRoute] and implement the
+// [ChildRoute] interface, supplying the parent route's type.
 class DashboardRoute extends SimpleRoute implements ChildRoute<RootRoute> {
+  // Pass the path of this route to the `super` constructor.
+  //
+  // Do not add any leading or trailing slashes - just the path segment for
+  // this route.
   const DashboardRoute() : super('dashboard');
 
-  // override the [parent] getter to return an instance of the parent route.
+  // Override the [parent] getter to return an instance of the parent route.
   @override
   RootRoute get parent => const RootRoute();
 }
 
-// Simple data route
+/*** Data Route Example ***/
 
-// Define some data for your route as a child of [SimpleRouteData].
+// Before defining the route class, we must define a data class as a child of
+// the [SimpleRouteData] base class.
+//
+// This class will be responsible for supplying the data needed to generate the
+// URL for your route.
+//
+// In this example, the "profile" route will require a value for the user ID,
+// so our data class will need a `userId` property. This value will then be
+// used in the [parameters] map to tell SimpleRoutes what and how to inject
+// the value.
 class ProfileRouteData extends SimpleRouteData {
   const ProfileRouteData({required this.userId});
 
@@ -35,12 +56,13 @@ class ProfileRouteData extends SimpleRouteData {
   // Override the [parameters] getter to define the parameters for this route.
   //
   // In this case, we want to inject the [userId] value into the path, replacing
-  // `:userId` in the path template.
+  // ":userId" in the path template.
   @override
   Map<String, String> get parameters => {'userId': userId};
 }
 
-// Define your route as a child of [SimpleDataRoute].
+// Then, define your route as a child of [SimpleDataRoute], providing the type
+// of your data class.
 class ProfileRoute extends SimpleDataRoute<ProfileRouteData> {
   // Since this is a [SimpleDataRoute], the path should contain some dynamic
   // variable, such as a userId. Make sure to prefix the value with a colon (:),
@@ -48,10 +70,14 @@ class ProfileRoute extends SimpleDataRoute<ProfileRouteData> {
   const ProfileRoute() : super('profile/:userId');
 }
 
-// Child data route
+/*** Data Route Child Example ***/
 
-// Define your route as a child of [SimpleDataRoute] with its appropriate data
-// type and implement the [ChildRoute] interface.
+// If you have child routes of a data route, they will also need to be data
+// routes. This is because the parent route(s) need their data, even if this
+// route does not.
+//
+// If the child route does not require any unique data of its own, simply extend
+// the [SimpleDataRoute] base class with the data type of its parent.
 class ProfileEditRoute extends SimpleDataRoute<ProfileRouteData>
     implements ChildRoute<ProfileRoute> {
   const ProfileEditRoute() : super('edit');
@@ -61,16 +87,47 @@ class ProfileEditRoute extends SimpleDataRoute<ProfileRouteData>
   ProfileRoute get parent => const ProfileRoute();
 }
 
-class ProfileEditRouteData extends ProfileRouteData {
-  const ProfileEditRouteData({
+// If, however, your child route requires its own data, such as a path parameter
+// or query params, you will need to create a new route data class. You can
+// create an entirely new route data class OR you can extend the parent's route
+// data class.
+class AdditionalRouteData extends ProfileRouteData {
+  const AdditionalRouteData({
+    // Make sure to provide any data needed by the parent route(s).
     required super.userId,
+    this.queryValue,
   });
 
-  // Define a factory or named constructor to easily extract the route data
-  // from a [GoRouterState].
-  factory ProfileEditRouteData.fromState(GoRouterState state) {
-    return ProfileEditRouteData(
-      userId: state.pathParameters['userId']!,
-    );
-  }
+  AdditionalRouteData.fromState(GoRouterState state)
+      : queryValue = state.uri.queryParameters['queryName'],
+        super(userId: state.pathParameters['userId']!);
+
+  final String? queryValue;
+
+  // If you don't need to add any parameters, you can get away with not
+  // overriding the parameters. Since we're extending the parent's route data
+  // class and providing it with its data, it will properly inject the
+  // parameters.
+  //
+  // @override
+  // Map<String, String> get parameters => {
+  //   'userId': userId,
+  // };
+
+  // Supply the data unique to this route. For example, an optional query
+  // param. If the value is null, it will not be added to the URL.
+  //
+  // All query parameter values are URL encoded.
+  @override
+  Map<String, String?> get query => {
+        'queryName': queryValue,
+      };
+}
+
+class AdditionalDataRoute extends SimpleDataRoute<AdditionalRouteData>
+    implements ChildRoute<ProfileRoute> {
+  const AdditionalDataRoute() : super('additional');
+
+  @override
+  ProfileRoute get parent => const ProfileRoute();
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,26 +92,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -148,10 +148,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -216,10 +216,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/routes.dart
+++ b/lib/src/routes.dart
@@ -1,51 +1,25 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:simple_routes/simple_routes.dart';
 
 /// An abstract class to serve as the parent for all routes.
 abstract class BaseRoute {
-  const BaseRoute();
+  const BaseRoute(this._path);
+  final String _path;
 
-  /// The path segment for this route. e.g. 'verify-email'.
-  abstract final String path;
-
-  /// Join a List<String> of path segments into a forward slash-separated path.
+  /// The path segment for this route, e.g. 'verify-email', used to configure
+  /// the `GoRoute.path` for this route.
   ///
-  /// e.g. ['auth', 'register', 'verify-email'] -> '/auth/register/verify-email'
-  ///
-  /// In debug mode, an assertion error will be thrown if any duplicate
-  /// segments are detected.
-  String fromSegments(List<String> segments) {
-    if (kDebugMode) {
-      final duplicates = segments.where((s1) {
-        return segments.where((s2) => s1 == s2).length > 1;
-      }).toList();
-
-      assert(
-        duplicates.isEmpty,
-        '[SimpleRoutes] WARNING: Path segments should be unique.\n'
-        '$runtimeType: Duplicates of ${[
-          ...Set.from(duplicates).map((x) => '"$x"'),
-        ].join(', ')}',
-      );
-    }
-
-    return segments.join('/');
-  }
-
-  /// Get the [GoRoute] `path` for this route.
-  ///
-  /// ```dart
+  ///  ```dart
   /// GoRoute(
-  ///   path: const MyRoute().goPath,
+  ///   path: const MyRoute().path,
   /// ),
   /// ```
-  String get goPath {
+  String get path {
     if (this is ChildRoute) {
-      return _ensureNoLeadingSlash(path);
+      return _ensureNoLeadingSlash(_path);
     } else {
-      return _ensureLeadingSlash(path);
+      return _ensureLeadingSlash(_path);
     }
   }
 
@@ -118,7 +92,9 @@ abstract class BaseRoute {
 /// }
 /// ```
 abstract class SimpleRoute extends BaseRoute {
-  const SimpleRoute();
+  const SimpleRoute(super._path);
+
+  static const root = '/';
 
   /// Navigate to this route.
   void go(BuildContext context) {
@@ -152,7 +128,7 @@ abstract class SimpleRoute extends BaseRoute {
 /// }
 /// ```
 abstract class SimpleDataRoute<Data extends SimpleRouteData> extends BaseRoute {
-  const SimpleDataRoute();
+  const SimpleDataRoute(super._path);
 
   static final _queryRegex = RegExp(r'\?.+$');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/andyhorn/simple_routes
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/test/simple_data_route_test.dart
+++ b/test/simple_data_route_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:simple_routes/simple_routes.dart';
 
 import 'mocks.dart';
+import 'test_routes.dart';
 
 void main() {
   late GoRouter router;
@@ -15,18 +16,18 @@ void main() {
     });
 
     group('#go', () {
-      testWidgets('navigates to the correct path', (tester) async {
+      testWidgets('navigates to the correct route', (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: MockGoRouterProvider(
               goRouter: router,
               child: Builder(builder: (context) {
                 return ElevatedButton(
-                  onPressed: () => const _TestRoute().go(
+                  onPressed: () => const TestDataRoute().go(
                     context,
-                    data: const _TestRouteData(
+                    data: const TestRouteData(
                       testValue: 'test-value',
-                      testData: _TestData(),
+                      testData: TestData(),
                       testQuery: 'test-query',
                     ),
                   ),
@@ -41,8 +42,8 @@ void main() {
 
         verify(
           () => router.go(
-            '/test-value?valueTwo=test-query',
-            extra: isA<_TestData>(),
+            '/test-value?query=test-query',
+            extra: isA<TestData>(),
           ),
         ).called(1);
       });
@@ -56,11 +57,11 @@ void main() {
               goRouter: router,
               child: Builder(builder: (context) {
                 return ElevatedButton(
-                  onPressed: () => const _TestRoute().push(
+                  onPressed: () => const TestDataRoute().push(
                     context,
-                    data: const _TestRouteData(
+                    data: const TestRouteData(
                       testValue: 'test-value',
-                      testData: _TestData(),
+                      testData: TestData(),
                       testQuery: 'test-query',
                     ),
                   ),
@@ -75,8 +76,8 @@ void main() {
 
         verify(
           () => router.push(
-            '/test-value?valueTwo=test-query',
-            extra: isA<_TestData>(),
+            '/test-value?query=test-query',
+            extra: isA<TestData>(),
           ),
         ).called(1);
       });
@@ -84,57 +85,16 @@ void main() {
 
     group('#fullPath', () {
       test('generates the correct path', () {
-        const route = _TestRoute();
+        const route = TestDataRoute();
         final generated = route.fullPath(
-          const _TestRouteData(
+          const TestRouteData(
             testValue: 'test-value',
-            testData: _TestData(),
+            testData: TestData(),
             testQuery: 'test query',
           ),
         );
-        expect(generated, '/test-value?valueTwo=test%20query');
+        expect(generated, '/test-value?query=test%20query');
       });
     });
   });
-}
-
-enum _TestEnum {
-  valueOne,
-  valueTwo,
-}
-
-class _TestData {
-  const _TestData();
-}
-
-class _TestRouteData extends SimpleRouteData {
-  const _TestRouteData({
-    required this.testQuery,
-    required this.testValue,
-    required this.testData,
-  });
-
-  final String testValue;
-  final String testQuery;
-  final _TestData testData;
-
-  @override
-  Map<String, String> get parameters => {
-        _TestEnum.valueOne.name: testValue,
-      };
-
-  @override
-  Map<String, String?> get query => {
-        _TestEnum.valueTwo.name: testQuery,
-      };
-
-  @override
-  Object? get extra => testData;
-}
-
-class _TestRoute extends SimpleDataRoute<_TestRouteData> {
-  const _TestRoute();
-
-  @override
-  String get path => _TestEnum.valueOne.template;
 }

--- a/test/simple_route_test.dart
+++ b/test/simple_route_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:simple_routes/simple_routes.dart';
 
 import 'mocks.dart';
 import 'test_routes.dart';
@@ -13,33 +12,26 @@ void main() {
   late TestBaseRoute route;
   late TestChildRoute childRoute;
 
-  group('Duplicate segments', () {
-    test('throws an error', () {
-      expect(
-        () => const _DuplicateTestRoute().fullPath(),
-        throwsA(isA<AssertionError>().having(
-          (e) => e.message,
-          'message',
-          '[SimpleRoutes] WARNING: Path segments should be unique.\n_DuplicateTestRoute: Duplicates of "test", ":param"',
-        )),
-      );
-    });
-  });
-
   group('Empty route', () {
     setUp(() {
       router = MockGoRouter();
       root = const TestEmptyRoute();
     });
 
+    group('.path', () {
+      test('returns correct path', () {
+        expect(root.path, equals('/'));
+      });
+    });
+
     group('#fullPath', () {
-      test('returns leading slash', () {
+      test('returns correct path', () {
         expect(root.fullPath(), '/');
       });
     });
   });
 
-  group('Root route', () {
+  group('Base route', () {
     setUp(() {
       router = MockGoRouter();
       route = const TestBaseRoute();
@@ -47,14 +39,14 @@ void main() {
     });
 
     group('#fullPath', () {
-      test('adds leading slash', () {
-        expect(route.fullPath(), '/test');
+      test('return correct path', () {
+        expect(route.fullPath(), '/base');
       });
     });
 
-    group('.goPath', () {
+    group('.path', () {
       test('returns correct path', () {
-        expect(route.goPath, '/test');
+        expect(route.path, '/base');
       });
     });
 
@@ -76,12 +68,12 @@ void main() {
 
         await tester.tap(find.text('click me'));
 
-        verify(() => router.go('/test')).called(1);
+        verify(() => router.go('/base')).called(1);
       });
     });
 
     group('#push', () {
-      testWidgets('pushed the correct path', (tester) async {
+      testWidgets('pushes the correct path', (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: MockGoRouterProvider(
@@ -98,37 +90,49 @@ void main() {
 
         await tester.tap(find.text('click me'));
 
-        verify(() => router.push('/test')).called(1);
+        verify(() => router.push('/base')).called(1);
       });
     });
   });
 
-  group('Slash route', () {
+  group('Root route', () {
+    group('.path', () {
+      test('returns correct path', () {
+        expect(const TestRootRoute().path, equals('/'));
+      });
+    });
+
     group('#fullPath', () {
-      test('returns slash', () {
+      test('returns correct path', () {
         expect(const TestRootRoute().fullPath(), '/');
       });
     });
   });
 
-  group('Slash child route', () {
+  group(TestRootChildRoute, () {
+    group('.path', () {
+      test('returns correct path', () {
+        expect(const TestRootChildRoute().path, equals('child'));
+      });
+    });
+
     group('#fullPath', () {
-      test('returns proper path', () {
-        expect(const TestSlashChildRoute().fullPath(), '/child');
+      test('returns correct path', () {
+        expect(const TestRootChildRoute().fullPath(), '/child');
       });
     });
   });
 
-  group('Child route', () {
+  group(TestChildRoute, () {
     group('#fullPath', () {
-      test('joins with parents', () {
-        expect(childRoute.fullPath(), '/test/child');
+      test('returns correct path', () {
+        expect(childRoute.fullPath(), '/base/child');
       });
     });
 
-    group('.goPath', () {
-      test('returns correct route', () {
-        expect(childRoute.goPath, 'child');
+    group('.path', () {
+      test('returns correct path', () {
+        expect(childRoute.path, 'child');
       });
     });
   });
@@ -154,7 +158,7 @@ void main() {
                 },
               ),
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   isCurrentRoute = const TestBaseRoute().isCurrentRoute(state);
                   return const Scaffold(
@@ -182,7 +186,7 @@ void main() {
             initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -225,7 +229,7 @@ void main() {
               initialLocation: const TestBaseRoute().fullPath(),
               routes: [
                 GoRoute(
-                  path: const TestBaseRoute().goPath,
+                  path: const TestBaseRoute().path,
                   builder: (context, state) {
                     return Scaffold(
                       body: ElevatedButton(
@@ -236,7 +240,7 @@ void main() {
                   },
                   routes: [
                     GoRoute(
-                      path: const TestChildRoute().goPath,
+                      path: const TestChildRoute().path,
                       builder: (context, state) {
                         isParent = const TestBaseRoute().isParentRoute(state);
                         return const Scaffold(
@@ -269,7 +273,7 @@ void main() {
               initialLocation: const TestBaseRoute().fullPath(),
               routes: [
                 GoRoute(
-                  path: const TestBaseRoute().goPath,
+                  path: const TestBaseRoute().path,
                   builder: (context, state) {
                     return Scaffold(
                       body: ElevatedButton(
@@ -322,7 +326,7 @@ void main() {
                 },
               ),
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   isActive = const TestBaseRoute().isActive(state);
                   return const Scaffold(
@@ -350,7 +354,7 @@ void main() {
             initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -389,7 +393,7 @@ void main() {
             initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -400,7 +404,7 @@ void main() {
                 },
                 routes: [
                   GoRoute(
-                    path: const TestChildRoute().goPath,
+                    path: const TestChildRoute().path,
                     builder: (context, state) {
                       isActive = const TestBaseRoute().isActive(state);
                       return const Scaffold(
@@ -434,7 +438,7 @@ void main() {
             initialLocation: const TestEmptyRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const TestEmptyRoute().goPath,
+                path: const TestEmptyRoute().path,
                 builder: (context, state) {
                   return Scaffold(
                     body: Column(
@@ -458,7 +462,7 @@ void main() {
                     navigatorKey: shellKey,
                     routes: [
                       GoRoute(
-                        path: const TestBaseRoute().goPath,
+                        path: const TestBaseRoute().path,
                         builder: (context, state) => const Scaffold(
                           body: Text('Test Route'),
                         ),
@@ -491,7 +495,7 @@ void main() {
             initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const TestBaseRoute().goPath,
+                path: const TestBaseRoute().path,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -506,7 +510,7 @@ void main() {
                 },
                 routes: [
                   GoRoute(
-                    path: const TestChildRoute().goPath,
+                    path: const TestChildRoute().path,
                     builder: (context, state) {
                       return Scaffold(
                         body: ElevatedButton(
@@ -534,20 +538,4 @@ void main() {
       expect(returnValue, 'hello world!');
     });
   });
-}
-
-enum _TestRouteParams {
-  param,
-}
-
-class _DuplicateTestRoute extends SimpleRoute {
-  const _DuplicateTestRoute();
-
-  @override
-  String get path => fromSegments([
-        'test',
-        'test',
-        _TestRouteParams.param.template,
-        _TestRouteParams.param.template,
-      ]);
 }

--- a/test/simple_route_test.dart
+++ b/test/simple_route_test.dart
@@ -5,12 +5,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:simple_routes/simple_routes.dart';
 
 import 'mocks.dart';
+import 'test_routes.dart';
 
 void main() {
   late GoRouter router;
-  late _TestRootRoute root;
-  late _TestRoute route;
-  late _TestChildRoute childRoute;
+  late TestEmptyRoute root;
+  late TestBaseRoute route;
+  late TestChildRoute childRoute;
 
   group('Duplicate segments', () {
     test('throws an error', () {
@@ -28,7 +29,7 @@ void main() {
   group('Empty route', () {
     setUp(() {
       router = MockGoRouter();
-      root = const _TestRootRoute();
+      root = const TestEmptyRoute();
     });
 
     group('#fullPath', () {
@@ -41,8 +42,8 @@ void main() {
   group('Root route', () {
     setUp(() {
       router = MockGoRouter();
-      route = const _TestRoute();
-      childRoute = const _TestChildRoute();
+      route = const TestBaseRoute();
+      childRoute = const TestChildRoute();
     });
 
     group('#fullPath', () {
@@ -65,7 +66,7 @@ void main() {
               goRouter: router,
               child: Builder(builder: (context) {
                 return ElevatedButton(
-                  onPressed: () => const _TestRoute().go(context),
+                  onPressed: () => const TestBaseRoute().go(context),
                   child: const Text('click me'),
                 );
               }),
@@ -87,7 +88,7 @@ void main() {
               goRouter: router,
               child: Builder(builder: (context) {
                 return ElevatedButton(
-                  onPressed: () => const _TestRoute().push(context),
+                  onPressed: () => const TestBaseRoute().push(context),
                   child: const Text('click me'),
                 );
               }),
@@ -105,7 +106,7 @@ void main() {
   group('Slash route', () {
     group('#fullPath', () {
       test('returns slash', () {
-        expect(const _TestSlashRoute().fullPath(), '/');
+        expect(const TestRootRoute().fullPath(), '/');
       });
     });
   });
@@ -113,7 +114,7 @@ void main() {
   group('Slash child route', () {
     group('#fullPath', () {
       test('returns proper path', () {
-        expect(const _TestSlashChildRoute().fullPath(), '/child');
+        expect(const TestSlashChildRoute().fullPath(), '/child');
       });
     });
   });
@@ -146,16 +147,16 @@ void main() {
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
-                      onPressed: () => const _TestRoute().go(context),
+                      onPressed: () => const TestBaseRoute().go(context),
                       child: const Text('click me'),
                     ),
                   );
                 },
               ),
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
-                  isCurrentRoute = const _TestRoute().isCurrentRoute(state);
+                  isCurrentRoute = const TestBaseRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -178,10 +179,10 @@ void main() {
       await tester.pumpWidget(
         MaterialApp.router(
           routerConfig: GoRouter(
-            initialLocation: const _TestRoute().fullPath(),
+            initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -194,7 +195,7 @@ void main() {
               GoRoute(
                 path: '/other-page',
                 builder: (context, state) {
-                  isCurrentRoute = const _TestRoute().isCurrentRoute(state);
+                  isCurrentRoute = const TestBaseRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -221,23 +222,23 @@ void main() {
         await tester.pumpWidget(
           MaterialApp.router(
             routerConfig: GoRouter(
-              initialLocation: const _TestRoute().fullPath(),
+              initialLocation: const TestBaseRoute().fullPath(),
               routes: [
                 GoRoute(
-                  path: const _TestRoute().goPath,
+                  path: const TestBaseRoute().goPath,
                   builder: (context, state) {
                     return Scaffold(
                       body: ElevatedButton(
-                        onPressed: () => const _TestChildRoute().go(context),
+                        onPressed: () => const TestChildRoute().go(context),
                         child: const Text('click me'),
                       ),
                     );
                   },
                   routes: [
                     GoRoute(
-                      path: const _TestChildRoute().goPath,
+                      path: const TestChildRoute().goPath,
                       builder: (context, state) {
-                        isParent = const _TestRoute().isParentRoute(state);
+                        isParent = const TestBaseRoute().isParentRoute(state);
                         return const Scaffold(
                           body: Text('Test Route'),
                         );
@@ -265,10 +266,10 @@ void main() {
         await tester.pumpWidget(
           MaterialApp.router(
             routerConfig: GoRouter(
-              initialLocation: const _TestRoute().fullPath(),
+              initialLocation: const TestBaseRoute().fullPath(),
               routes: [
                 GoRoute(
-                  path: const _TestRoute().goPath,
+                  path: const TestBaseRoute().goPath,
                   builder: (context, state) {
                     return Scaffold(
                       body: ElevatedButton(
@@ -281,7 +282,7 @@ void main() {
                 GoRoute(
                   path: '/other-path',
                   builder: (context, state) {
-                    isParent = const _TestRoute().isParentRoute(state);
+                    isParent = const TestBaseRoute().isParentRoute(state);
                     return const Scaffold(
                       body: Text('Test Route'),
                     );
@@ -314,16 +315,16 @@ void main() {
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
-                      onPressed: () => const _TestRoute().go(context),
+                      onPressed: () => const TestBaseRoute().go(context),
                       child: const Text('click me'),
                     ),
                   );
                 },
               ),
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
-                  isActive = const _TestRoute().isActive(state);
+                  isActive = const TestBaseRoute().isActive(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -346,10 +347,10 @@ void main() {
       await tester.pumpWidget(
         MaterialApp.router(
           routerConfig: GoRouter(
-            initialLocation: const _TestRoute().fullPath(),
+            initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
@@ -362,7 +363,7 @@ void main() {
               GoRoute(
                 path: '/other-page',
                 builder: (context, state) {
-                  isActive = const _TestRoute().isCurrentRoute(state);
+                  isActive = const TestBaseRoute().isCurrentRoute(state);
                   return const Scaffold(
                     body: Text('Test Route'),
                   );
@@ -385,23 +386,23 @@ void main() {
       await tester.pumpWidget(
         MaterialApp.router(
           routerConfig: GoRouter(
-            initialLocation: const _TestRoute().fullPath(),
+            initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
-                      onPressed: () => const _TestChildRoute().go(context),
+                      onPressed: () => const TestChildRoute().go(context),
                       child: const Text('click me'),
                     ),
                   );
                 },
                 routes: [
                   GoRoute(
-                    path: const _TestChildRoute().goPath,
+                    path: const TestChildRoute().goPath,
                     builder: (context, state) {
-                      isActive = const _TestRoute().isActive(state);
+                      isActive = const TestBaseRoute().isActive(state);
                       return const Scaffold(
                         body: Text('Test Route'),
                       );
@@ -430,17 +431,17 @@ void main() {
         MaterialApp.router(
           routerConfig: GoRouter(
             navigatorKey: rootKey,
-            initialLocation: const _TestRootRoute().fullPath(),
+            initialLocation: const TestEmptyRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const _TestRootRoute().goPath,
+                path: const TestEmptyRoute().goPath,
                 builder: (context, state) {
                   return Scaffold(
                     body: Column(
                       children: [
                         const Text('Root Route'),
                         ElevatedButton(
-                          onPressed: () => const _TestRoute().go(context),
+                          onPressed: () => const TestBaseRoute().go(context),
                           child: const Text('Click me'),
                         ),
                       ],
@@ -457,7 +458,7 @@ void main() {
                     navigatorKey: shellKey,
                     routes: [
                       GoRoute(
-                        path: const _TestRoute().goPath,
+                        path: const TestBaseRoute().goPath,
                         builder: (context, state) => const Scaffold(
                           body: Text('Test Route'),
                         ),
@@ -487,15 +488,15 @@ void main() {
       await tester.pumpWidget(
         MaterialApp.router(
           routerConfig: GoRouter(
-            initialLocation: const _TestRoute().fullPath(),
+            initialLocation: const TestBaseRoute().fullPath(),
             routes: [
               GoRoute(
-                path: const _TestRoute().goPath,
+                path: const TestBaseRoute().goPath,
                 builder: (context, state) {
                   return Scaffold(
                     body: ElevatedButton(
                       onPressed: () async {
-                        returnValue = await const _TestChildRoute().push(
+                        returnValue = await const TestChildRoute().push(
                           context,
                         );
                       },
@@ -505,7 +506,7 @@ void main() {
                 },
                 routes: [
                   GoRoute(
-                    path: const _TestChildRoute().goPath,
+                    path: const TestChildRoute().goPath,
                     builder: (context, state) {
                       return Scaffold(
                         body: ElevatedButton(
@@ -537,48 +538,6 @@ void main() {
 
 enum _TestRouteParams {
   param,
-}
-
-class _TestRootRoute extends SimpleRoute {
-  const _TestRootRoute();
-
-  @override
-  final String path = '';
-}
-
-class _TestSlashRoute extends SimpleRoute {
-  const _TestSlashRoute();
-
-  @override
-  final String path = '/';
-}
-
-class _TestSlashChildRoute extends SimpleRoute
-    implements ChildRoute<_TestSlashRoute> {
-  const _TestSlashChildRoute();
-
-  @override
-  final _TestSlashRoute parent = const _TestSlashRoute();
-
-  @override
-  final String path = 'child';
-}
-
-class _TestRoute extends SimpleRoute {
-  const _TestRoute();
-
-  @override
-  final String path = 'test';
-}
-
-class _TestChildRoute extends SimpleRoute implements ChildRoute<_TestRoute> {
-  const _TestChildRoute();
-
-  @override
-  final _TestRoute parent = const _TestRoute();
-
-  @override
-  final String path = 'child';
 }
 
 class _DuplicateTestRoute extends SimpleRoute {

--- a/test/test_routes.dart
+++ b/test/test_routes.dart
@@ -4,16 +4,16 @@ class TestEmptyRoute extends SimpleRoute {
   const TestEmptyRoute() : super('');
 }
 
-class TestSlashRoute extends SimpleRoute {
-  const TestSlashRoute() : super(SimpleRoute.root);
+class TestRootRoute extends SimpleRoute {
+  const TestRootRoute() : super(SimpleRoute.root);
 }
 
-class TestSlashChildRoute extends SimpleRoute
-    implements ChildRoute<TestSlashRoute> {
-  const TestSlashChildRoute() : super('child');
+class TestRootChildRoute extends SimpleRoute
+    implements ChildRoute<TestRootRoute> {
+  const TestRootChildRoute() : super('child');
 
   @override
-  final TestSlashRoute parent = const TestSlashRoute();
+  final TestRootRoute parent = const TestRootRoute();
 }
 
 class TestBaseRoute extends SimpleRoute {

--- a/test/test_routes.dart
+++ b/test/test_routes.dart
@@ -1,0 +1,61 @@
+import 'package:simple_routes/simple_routes.dart';
+
+class TestEmptyRoute extends SimpleRoute {
+  const TestEmptyRoute() : super('');
+}
+
+class TestSlashRoute extends SimpleRoute {
+  const TestSlashRoute() : super(SimpleRoute.root);
+}
+
+class TestSlashChildRoute extends SimpleRoute
+    implements ChildRoute<TestSlashRoute> {
+  const TestSlashChildRoute() : super('child');
+
+  @override
+  final TestSlashRoute parent = const TestSlashRoute();
+}
+
+class TestBaseRoute extends SimpleRoute {
+  const TestBaseRoute() : super('base');
+}
+
+class TestChildRoute extends SimpleRoute implements ChildRoute<TestBaseRoute> {
+  const TestChildRoute() : super('child');
+
+  @override
+  final TestBaseRoute parent = const TestBaseRoute();
+}
+
+class TestData {
+  const TestData();
+}
+
+class TestRouteData extends SimpleRouteData {
+  const TestRouteData({
+    required this.testQuery,
+    required this.testValue,
+    required this.testData,
+  });
+
+  final String testValue;
+  final String testQuery;
+  final TestData testData;
+
+  @override
+  Map<String, String> get parameters => {
+        'param': testValue,
+      };
+
+  @override
+  Map<String, String?> get query => {
+        'query': testQuery,
+      };
+
+  @override
+  Object? get extra => testData;
+}
+
+class TestDataRoute extends SimpleDataRoute<TestRouteData> {
+  const TestDataRoute() : super(':param');
+}


### PR DESCRIPTION
Move the "path" value into the super ctor and revamp the "path" property to return the GoRoute-friendly path segment. This replaces the "goPath" property and cleans up the API.

- **Update flutter constraint**
- **Move path into ctor**
- **Update example app and routes**
- **Remove the "filter" example**
- **Get rid of the route params enum**
- **Add test routes file**
- **Use extracted routes in tests**
- **Fix tests**
- **Update root example**
- **Improve example**
